### PR TITLE
aider: Add Playwright support and cleanup logic

### DIFF
--- a/src/aider/CHANGELOG.md
+++ b/src/aider/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- Support for installing dependencies like Playwright and browser dependencies to enable Aider's web scraping functionality.
+- Logic to clean up caches and other temporary files after installation to optimize performance and reduce disk usage.
+
+## [1.0.0] - 2024-12-18
+
+### Added
+
+- Initial implementation of Aider devcontainer feature with support for Debian and Ubuntu.
+
+[Unreleased]: https://github.com/ivy/devcontainer-features/commits/main/src/aider
+[1.0.0]: https://github.com/ivy/devcontainer-features/commits/main/src/aider?since=2024-12-18&until=2024-12-19

--- a/src/aider/devcontainer-feature.json
+++ b/src/aider/devcontainer-feature.json
@@ -14,6 +14,28 @@
         "0.69.1"
       ],
       "description": "Select an Aider version to install."
+    },
+    "installPlaywright": {
+      "type": "boolean",
+      "default": true,
+      "description": "Install Playwright for the best web scraping."
+    },
+    "installPlaywrightBrowsers": {
+      "type": "string",
+      "default": "chromium",
+      "proposals": [
+        "chromium",
+        "chromium-headless-shell",
+        "chrome",
+        "chrome-beta",
+        "msedge",
+        "msedge-beta",
+        "msedge-dev",
+        "bidi-chromium",
+        "firefox",
+        "webkit"
+      ],
+      "description": "Select the browsers to install for Playwright (comma-delimit for multiple)."
     }
   },
   "dependsOn": {

--- a/src/aider/install.sh
+++ b/src/aider/install.sh
@@ -114,9 +114,6 @@ clean_up() {
     # Clean up pipx cache.
     as_user 'pipx runpip aider-chat cache purge'
 
-    # Clean up Playwright cache (browser packages).
-    as_user 'rm -fr ~/.cache/ms-playwright'
-
     if [ "$ADJUSTED_ID" = debian ]; then
         rm -fr /var/lib/apt/lists/*
     fi

--- a/src/aider/install.sh
+++ b/src/aider/install.sh
@@ -76,8 +76,12 @@ detect_username() {
 }
 
 as_user() {
+    # HACK(ivy): PS1=true works around an edge case where pipx isn't added
+    # to the PATH. This happens with the `mcr.microsoft.com/devcontainers/base:ubuntu`
+    # image which includes a check at the top of /etc/bash.bashrc which
+    # returns in non-interactive shells.
     if [ "$USERNAME" = root ]; then
-        "$@"
+        bash -c "PS1=true; . /etc/bash.bashrc || true; $1"
     else
         su - "$USERNAME" bash -c "PS1=true; . /etc/bash.bashrc || true; $1"
     fi
@@ -86,16 +90,8 @@ as_user() {
 # Install Aider using pipx.
 install_aider() {
     if [ "$AIDER_VERSION" = latest ]; then
-        # NOTE(ivy): PS1=true works around an edge case where pipx isn't added
-        # to the PATH. This happens with the `mcr.microsoft.com/devcontainers/base:ubuntu`
-        # image which includes a check at the top of /etc/bash.bashrc which
-        # returns in non-interactive shells.
         as_user 'pipx install aider-chat'
     else
-        # NOTE(ivy): PS1=true works around an edge case where pipx isn't added
-        # to the PATH. This happens with the `mcr.microsoft.com/devcontainers/base:ubuntu`
-        # image which includes a check at the top of /etc/bash.bashrc which
-        # returns in non-interactive shells.
         as_user "pipx install aider-chat==${AIDER_VERSION}"
     fi
 }

--- a/src/aider/install.sh
+++ b/src/aider/install.sh
@@ -97,6 +97,8 @@ install_aider() {
 }
 
 install_playwright() {
+    local browsers
+
     if [ "$INSTALLPLAYWRIGHT" != true ]; then
         return
     fi
@@ -104,8 +106,11 @@ install_playwright() {
     as_user 'pipx inject --include-apps --include-deps aider-chat playwright'
 
     if [ -n "$INSTALLPLAYWRIGHTBROWSERS" ]; then
+        # Split $INSTALLPLAYWRIGHTBROWSERS by comma into an array and bind it to $browsers.
+        IFS=, read -r -a browsers <<< "$INSTALLPLAYWRIGHTBROWSERS"
+
         echo "Installing Playwright browsers: $INSTALLPLAYWRIGHTBROWSERS..."
-        as_user "playwright install --with-deps $INSTALLPLAYWRIGHTBROWSERS"
+        as_user "playwright install --with-deps ${browsers[*]}"
     fi
 }
 

--- a/src/aider/install.sh
+++ b/src/aider/install.sh
@@ -14,8 +14,34 @@ set -o pipefail
 # Version of Aider to install.
 AIDER_VERSION="${VERSION:-latest}"
 
+# Whether to install Playwright for web scraping.
+INSTALLPLAYWRIGHT="${INSTALLPLAYWRIGHT:-true}"
+
+# Browsers to install for Playwright.
+INSTALLPLAYWRIGHTBROWSERS="${INSTALLPLAYWRIGHTBROWSERS:-chromium}"
+
 # Username to install Aider for.
 USERNAME="${USERNAME:-"${_REMOTE_USER:-automatic}"}"
+
+# Detect the Linux distribution ID. Adjust to account for derivatives.
+detect_adjusted_id() {
+    if [ ! -r /etc/os-release ]; then
+        echo "WARN: Unable to detect the OS release." >&2
+        return
+    fi
+
+    # shellcheck disable=SC1091
+    source /etc/os-release
+
+    case "${ID:-unknown}" in
+        debian|ubuntu)
+            ADJUSTED_ID=debian
+            ;;
+        *)
+            ADJUSTED_ID="${ID:-unknown}"
+            ;;
+    esac
+}
 
 # Detect the username to use for the installation. This code is adapted from the
 # official devcontainer Python feature.
@@ -49,6 +75,57 @@ detect_username() {
     fi
 }
 
+as_user() {
+    if [ "$USERNAME" = root ]; then
+        "$@"
+    else
+        su - "$USERNAME" bash -c "PS1=true; . /etc/bash.bashrc || true; $1"
+    fi
+}
+
+# Install Aider using pipx.
+install_aider() {
+    if [ "$AIDER_VERSION" = latest ]; then
+        # NOTE(ivy): PS1=true works around an edge case where pipx isn't added
+        # to the PATH. This happens with the `mcr.microsoft.com/devcontainers/base:ubuntu`
+        # image which includes a check at the top of /etc/bash.bashrc which
+        # returns in non-interactive shells.
+        as_user 'pipx install aider-chat'
+    else
+        # NOTE(ivy): PS1=true works around an edge case where pipx isn't added
+        # to the PATH. This happens with the `mcr.microsoft.com/devcontainers/base:ubuntu`
+        # image which includes a check at the top of /etc/bash.bashrc which
+        # returns in non-interactive shells.
+        as_user "pipx install aider-chat==${AIDER_VERSION}"
+    fi
+}
+
+install_playwright() {
+    if [ "$INSTALLPLAYWRIGHT" != true ]; then
+        return
+    fi
+
+    as_user 'pipx inject --include-apps --include-deps aider-chat playwright'
+
+    if [ -n "$INSTALLPLAYWRIGHTBROWSERS" ]; then
+        echo "Installing Playwright browsers: $INSTALLPLAYWRIGHTBROWSERS..."
+        as_user "playwright install --with-deps $INSTALLPLAYWRIGHTBROWSERS"
+    fi
+}
+
+# Clean up caches and temporary files.
+clean_up() {
+    # Clean up pipx cache.
+    as_user 'pipx runpip aider-chat cache purge'
+
+    # Clean up Playwright cache (browser packages).
+    as_user 'rm -fr ~/.cache/ms-playwright'
+
+    if [ "$ADJUSTED_ID" = debian ]; then
+        rm -fr /var/lib/apt/lists/*
+    fi
+}
+
 # Main entrypoint
 main() {
     if [ "$(id -u)" -ne 0 ]; then
@@ -56,22 +133,11 @@ main() {
         exit 1
     fi
 
+    detect_adjusted_id
     detect_username
-    if [ "$AIDER_VERSION" = latest ]; then
-        echo "Installing latest Aider..."
-        # NOTE(ivy): PS1=true works around an edge case where pipx isn't added
-        # to the PATH. This happens with the `mcr.microsoft.com/devcontainers/base:ubuntu`
-        # image which includes a check at the top of /etc/bash.bashrc which
-        # returns in non-interactive shells.
-        su - "$USERNAME" bash -c "PS1=true; . /etc/bash.bashrc || true; pipx install aider-chat"
-    else
-        echo "Installing Aider version $AIDER_VERSION..."
-        # NOTE(ivy): PS1=true works around an edge case where pipx isn't added
-        # to the PATH. This happens with the `mcr.microsoft.com/devcontainers/base:ubuntu`
-        # image which includes a check at the top of /etc/bash.bashrc which
-        # returns in non-interactive shells.
-        su - "$USERNAME" bash -c "PS1=true; . /etc/bash.bashrc || true; pipx install aider-chat==${AIDER_VERSION}"
-    fi
+    install_aider
+    install_playwright
+    clean_up
 
     echo "Aider has been installed!"
 }

--- a/test/aider/scenarios.json
+++ b/test/aider/scenarios.json
@@ -16,5 +16,13 @@
               "version": "0.69.0"
           }
       }
+  },
+  "without_playwright": {
+      "image": "mcr.microsoft.com/devcontainers/base:debian",
+      "features": {
+          "aider": {
+              "installPlaywright": false
+          }
+      }
   }
 }

--- a/test/aider/scenarios.json
+++ b/test/aider/scenarios.json
@@ -24,5 +24,13 @@
               "installPlaywright": false
           }
       }
+  },
+  "with_playwright_browsers": {
+      "image": "mcr.microsoft.com/devcontainers/base:debian",
+      "features": {
+          "aider": {
+              "installPlaywrightBrowsers": "chromium,firefox"
+          }
+      }
   }
 }

--- a/test/aider/test.sh
+++ b/test/aider/test.sh
@@ -42,6 +42,7 @@ source dev-container-features-test-lib
 # The 'check' command comes from the dev-container-features-test-lib. Syntax is...
 # check <LABEL> <cmd> [args...]
 check "validate aider installed" command -v aider
+check "validate playwright installed" command -v playwright
 
 # Report result
 # If any of the checks above exited with a non-zero exit code, the test will fail.

--- a/test/aider/with_playwright_browsers.sh
+++ b/test/aider/with_playwright_browsers.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# This test file will be executed against one of the scenarios devcontainer.json test that
+# includes the 'color' feature with "favorite": "gold" option.
+
+set -e
+
+# Optional: Import test library bundled with the devcontainer CLI
+# shellcheck disable=SC1091
+source dev-container-features-test-lib
+
+# Feature-specific tests
+# The 'check' command comes from the dev-container-features-test-lib.
+# shellcheck disable=SC2016
+check "chromium is installed" bash -c 'find ~/.cache/ms-playwright -maxdepth 1 -type d | grep -E chromium'
+check "firefox is installed" bash -c 'find ~/.cache/ms-playwright -maxdepth 1 -type d | grep -E firefox'
+
+# Report result
+# If any of the checks above exited with a non-zero exit code, the test will fail.
+reportResults

--- a/test/aider/without_playwright.sh
+++ b/test/aider/without_playwright.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# This test file will be executed against one of the scenarios devcontainer.json test that
+# includes the 'color' feature with "favorite": "gold" option.
+
+set -e
+
+# Optional: Import test library bundled with the devcontainer CLI
+# shellcheck disable=SC1091
+source dev-container-features-test-lib
+
+# Feature-specific tests
+# The 'check' command comes from the dev-container-features-test-lib.
+# shellcheck disable=SC2016
+check "playwright is not installed" bash -c '! command -v playwright'
+
+# Report result
+# If any of the checks above exited with a non-zero exit code, the test will fail.
+reportResults


### PR DESCRIPTION
This pull request enables Aider's web scraping functionality by installing Playwright and its browser dependencies. Users can enable or disable Playwright install and select which browsers they want to install, if any.

## Changes

1. **Playwright Support**:
   - Introduced Playwright installation logic in `install.sh`.
   - Enabled configuration of Playwright and browser selection via `devcontainer-feature.json`.
2. **Improved Installation Script**:
   - Refactored logic to improve modularity and maintainability.
   - Implemented OS-specific and user-detection logic.
3. **Testing**:
   - Expanded `scenarios.json` to include tests for Playwright and browser installs.
   - Added new scripts:
     - `without_playwright.sh` to test that Playwright install can be disabled.
     - `with_playwright_browsers.sh` to validate the successful installation of specific browsers.
4. **Cache Management**:
   - Added a `clean_up` function and Debian/Ubuntu detection to purge apt lists and pipx cache.
5. **Changelog Introduction**:
   - Added a `CHANGELOG.md` following the [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) format for better documentation and release tracking.