### PR TITLE
aider: Prepare for 1.1.0 release

### DIFF
--- a/src/aider/CHANGELOG.md
+++ b/src/aider/CHANGELOG.md
@@ -6,16 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## 1.1.0 - 2024-12-20
+
 ### Added
 
 - Support for installing dependencies like Playwright and browser dependencies to enable Aider's web scraping functionality.
 - Logic to clean up caches and other temporary files after installation to optimize performance and reduce disk usage.
 
-## [1.0.0] - 2024-12-18
+## 1.0.0 - 2024-12-18
 
 ### Added
 
 - Initial implementation of Aider devcontainer feature with support for Debian and Ubuntu.
-
-[Unreleased]: https://github.com/ivy/devcontainer-features/commits/main/src/aider
-[1.0.0]: https://github.com/ivy/devcontainer-features/commits/main/src/aider?since=2024-12-18&until=2024-12-19

--- a/src/aider/devcontainer-feature.json
+++ b/src/aider/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
   "id": "aider",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "name": "Aider",
   "description": "Aider lets you pair program with LLMs, to edit code in your local Git repository.",
   "documentationURL": "https://github.com/ivy/devcontainer-features/blob/main/src/aider#readme",


### PR DESCRIPTION
This pull request updates the changelog and bumps the version to `1.1.0`.